### PR TITLE
Batch of fixes for Sashimi.AzureResourceGroup to target Server 2020.5

### DIFF
--- a/source/Calamari/App.config
+++ b/source/Calamari/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+    <runtime>
+        <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+    </runtime>
+</configuration>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,20 +9,15 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.AzureScripting" Version="9.0.2" />
-    <PackageReference Include="Calamari.Scripting" Version="8.3.4" />
-    <PackageReference Include="Calamari.Common" Version="14.11.4" />
+    <PackageReference Include="Calamari.Common" Version="15.1.6" />
+    <PackageReference Include="Calamari.AzureScripting" Version="9.2.0" />
+    <PackageReference Include="Calamari.Scripting" Version="8.4.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.9.0-preview" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Sashimi.Server.Contracts">
-      <Version>6.1.0</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.3.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.5.4" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
     <PackageReference Include="Assent" Version="1.6.1" />
   </ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -15,7 +15,7 @@
     <None Include="..\..\artifacts\Calamari.AzureResourceGroup.zip" LinkBase="tools" Pack="true" PackagePath="tools/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="9.0.2" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="8.3.4" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="9.2.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.5.4" />
   </ItemGroup>
 </Project>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.38.5" />
+</packages>


### PR DESCRIPTION
Fixes both:
- https://github.com/OctopusDeploy/Issues/issues/6683
- https://github.com/OctopusDeploy/Issues/issues/6778

For netfull we need to explicitly enable long file paths in the config file.
Update references to Calamari + Sashimi to match what the Server is referencing
Had to lock the cake version because v1 does not work!

Cake error with v1:
![image](https://user-images.githubusercontent.com/122651/109563561-ab23ea80-7b2b-11eb-9406-c83ad9dc4a59.png)
