### PR TITLE
Update references to Calamari + Sashimi for targeting 2020.6 server

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 </Project>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Calamari.Common" Version="17.0.1" />
-    <PackageReference Include="Calamari.AzureScripting" Version="10.0.0" />
+    <PackageReference Include="Calamari.AzureScripting" Version="10.0.1" />
     <PackageReference Include="Calamari.Scripting" Version="8.6.4" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,9 +9,9 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="15.1.6" />
-    <PackageReference Include="Calamari.AzureScripting" Version="9.2.0" />
-    <PackageReference Include="Calamari.Scripting" Version="8.4.0" />
+    <PackageReference Include="Calamari.Common" Version="17.0.1" />
+    <PackageReference Include="Calamari.AzureScripting" Version="10.0.0" />
+    <PackageReference Include="Calamari.Scripting" Version="8.6.4" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.9.0-preview" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -10,12 +10,12 @@
     <ProjectReference Include="..\Sashimi\Sashimi.csproj" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.33.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.34.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.5.4" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.4" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     <PackageReference Include="Assent" Version="1.6.1" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     <PackageReference Include="Assent" Version="1.6.1" />
   </ItemGroup>

--- a/source/Sashimi/AzureResourceGroupActionHandler.cs
+++ b/source/Sashimi/AzureResourceGroupActionHandler.cs
@@ -19,7 +19,7 @@ namespace Sashimi.AzureResourceGroup
         public IActionHandlerResult Execute(IActionHandlerContext context)
         {
             var templateInPackage = context.Variables.Get(SpecialVariables.Action.AzureResourceGroup.TemplateSource, String.Empty) == "Package";
-            var template = context.Variables.Get(SpecialVariables.Action.AzureResourceGroup.ResourceGroupTemplate);
+            var template = context.Variables.Get(SpecialVariables.Action.AzureResourceGroup.ResourceGroupTemplate)!;
             var templateParameters = GetTemplateParameters();
 
             var builder = context.CalamariCommand(AzureConstants.CalamariAzure, "deploy-azure-resource-group")
@@ -38,10 +38,10 @@ namespace Sashimi.AzureResourceGroup
             {
                 if (templateInPackage)
                 {
-                    return context.Variables.Get(SpecialVariables.Action.AzureResourceGroup.ResourceGroupTemplateParameters);
+                    return context.Variables.Get(SpecialVariables.Action.AzureResourceGroup.ResourceGroupTemplateParameters)!;
                 }
 
-                var parametersJson = context.Variables.GetRaw(SpecialVariables.Action.AzureResourceGroup.ResourceGroupTemplateParameters);
+                var parametersJson = context.Variables.GetRaw(SpecialVariables.Action.AzureResourceGroup.ResourceGroupTemplateParameters)!;
 
                 var parameterMetadata = AzureResourceGroupActionUtils.ExtractParameterTypes(template);
                 return AzureResourceGroupActionUtils.TemplateParameters(parametersJson, parameterMetadata, context.Variables);

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -15,7 +15,7 @@
     <None Include="..\..\artifacts\Calamari.AzureResourceGroup.zip" LinkBase="tools" Pack="true" PackagePath="tools/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.4" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.1" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.0" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -15,7 +15,7 @@
     <None Include="..\..\artifacts\Calamari.AzureResourceGroup.zip" LinkBase="tools" Pack="true" PackagePath="tools/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="9.2.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="8.5.4" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
This PR completes the work started in https://github.com/OctopusDeploy/Sashimi.AzureResourceGroup/pull/6

This PR increases the Calamari version to 17.0.1 (Server v2020.6 is still on Calamari v16.0.7), as part of merging this PR with the Server I will be bumping the Calamari version to match the one in this PR.

### Is it safe to bump Calamari to v17.0.1?
Yes I have reviewed the changes - https://github.com/OctopusDeploy/Calamari/compare/16.0.7...17.0.1