### PR TITLE
Bump Calamari.AzureScripting to 14.0.2

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,9 +9,9 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="20.3.6" />
-    <PackageReference Include="Calamari.AzureScripting" Version="14.0.1" />
-    <PackageReference Include="Calamari.Scripting" Version="14.0.2" />
+    <PackageReference Include="Calamari.Common" Version="20.4.0" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.0.2" />
+    <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.9.0-preview" />


### PR DESCRIPTION
Rolling dependency changes through to keep things up to date, no functional changes in this Sashimi as it's not a "Run a Script" step.

(Version bump results from fix for OctopusDeploy/Issues#7050, which changed the way Bash Script parameters are handled)