### PR TITLE
Bumps Calamari.* to 18.1.7, Sashimi.* to 9.0.3, AzureScripting.* to 11.0.3 (Server 2021.1 stream)

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,9 +9,9 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="18.1.4" />
-    <PackageReference Include="Calamari.AzureScripting" Version="11.0.2" />
-    <PackageReference Include="Calamari.Scripting" Version="9.0.2" />
+    <PackageReference Include="Calamari.Common" Version="18.1.7" />
+    <PackageReference Include="Calamari.AzureScripting" Version="11.0.3" />
+    <PackageReference Include="Calamari.Scripting" Version="9.0.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.22" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.9.0-preview" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="12.1.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.2" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     <PackageReference Include="Assent" Version="1.6.1" />
   </ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -15,7 +15,7 @@
     <None Include="..\..\artifacts\Calamari.AzureResourceGroup.zip" LinkBase="tools" Pack="true" PackagePath="tools/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="11.0.2" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="9.0.2" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="11.0.3" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="9.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.1.

Upstream changes:
* OctopusDeploy/Calamari#805
* OctopusDeploy/Sashimi#130
* OctopusDeploy/Sashimi.AzureScripting#18

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177