### PR TITLE
Bumps Calamari.* to 19.4.10 and Sashimi.* to 14.0.3 (Server 2021.2 Stream)

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,9 +9,9 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="19.4.6" />
-    <PackageReference Include="Calamari.AzureScripting" Version="14.0.0" />
-    <PackageReference Include="Calamari.Scripting" Version="14.0.1" />
+    <PackageReference Include="Calamari.Common" Version="19.4.10" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.0.3" />
+    <PackageReference Include="Calamari.Scripting" Version="14.0.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.9.0-preview" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     <PackageReference Include="Assent" Version="1.6.1" />
   </ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -15,7 +15,7 @@
     <None Include="..\..\artifacts\Calamari.AzureResourceGroup.zip" LinkBase="tools" Pack="true" PackagePath="tools/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.3" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Upstream changes:
* OctopusDeploy/Calamari#808
* OctopusDeploy/Sashimi#133
* OctopusDeploy/Sashimi.AzureScripting#19

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177