### PR TITLE
Bumps Calamari.* to 20.4.2, Sashimi.* to 14.1.3, and Sashimi.AzureScripting to 14.1.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -117,6 +117,8 @@ Task("PublishCalamariProjects")
                         Framework = framework,
                         Runtime = runtime
 		    	    });
+		    	    
+		    	    CopyFiles("./global.json", $"{publishDir}/{calamariFlavour}/{platform}");
                 }
 
                 if(framework.StartsWith("netcoreapp"))
@@ -149,6 +151,8 @@ Task("PublishSashimiTestProjects")
 		    	    	Configuration = configuration,
                         OutputDirectory = $"{publishDir}/{sashimiFlavour}"
 		    	    });
+		    	    
+		    	    CopyFiles("./global.json", $"{publishDir}/{sashimiFlavour}");
                 }
 
                 RunPublish();

--- a/build.cake
+++ b/build.cake
@@ -121,7 +121,7 @@ Task("PublishCalamariProjects")
 		    	    CopyFiles("./global.json", $"{publishDir}/{calamariFlavour}/{platform}");
                 }
 
-                if(framework.StartsWith("netcoreapp"))
+                if(framework.Equals("net5.0"))
                 {
                     var runtimes = XmlPeek(project, "Project/PropertyGroup/RuntimeIdentifiers").Split(';');
                     foreach(var runtime in runtimes)

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "5.0.100",
+        "rollForward": "latestFeature"
+    }
+}

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Calamari.AzureResourceGroup.Tests</RootNamespace>
     <AssemblyName>Calamari.AzureResourceGroup.Tests</AssemblyName>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,9 +9,9 @@
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="20.4.0" />
-    <PackageReference Include="Calamari.AzureScripting" Version="14.0.2" />
-    <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
+    <PackageReference Include="Calamari.Common" Version="20.4.2" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.1.0" />
+    <PackageReference Include="Calamari.Scripting" Version="14.1.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.9.0-preview" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;net5.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>

--- a/source/Calamari/DeployAzureResourceGroupBehaviour.cs
+++ b/source/Calamari/DeployAzureResourceGroupBehaviour.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.Management.ResourceManager.Models;
 using Microsoft.Rest;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using AzureResourceManagerDeployment = Microsoft.Azure.Management.ResourceManager.Models.Deployment;
 
 namespace Calamari.AzureResourceGroup
 {
@@ -117,7 +118,7 @@ namespace Calamari.AzureResourceGroup
             {
                 var createDeploymentResult = await armClient.Deployments.BeginCreateOrUpdateAsync(resourceGroupName,
                                                                                                   deploymentName,
-                                                                                                  new Deployment
+                                                                                                  new AzureResourceManagerDeployment
                                                                                                   {
                                                                                                       Properties = new DeploymentProperties
                                                                                                       {

--- a/source/Sashimi.Tests/AzureResourceGroupActionUtilsFixture.cs
+++ b/source/Sashimi.Tests/AzureResourceGroupActionUtilsFixture.cs
@@ -98,7 +98,7 @@ namespace Sashimi.AzureResourceGroup.Tests
         {
            public string GetName(TestMetadata metadata)
            {
-              var directoryName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().FullLocalPath());
+              var directoryName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
               return Path.Combine(directoryName, $"{metadata.TestFixture.GetType().Name}.{metadata.TestName}");
            }

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.3.3" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
     <PackageReference Include="Assent" Version="1.6.1" />
   </ItemGroup>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -3,7 +3,7 @@
     <RootNamespace>Sashimi.AzureResourceGroup.Tests</RootNamespace>
     <AssemblyName>Sashimi.AzureResourceGroup.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Calamari\Calamari.csproj" />

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -15,7 +15,7 @@
     <None Include="..\..\artifacts\Calamari.AzureResourceGroup.zip" LinkBase="tools" Pack="true" PackagePath="tools/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="14.1.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.1.3" />
   </ItemGroup>
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Sashimi.AzureResourceGroup</RootNamespace>
     <AssemblyName>Sashimi.AzureResourceGroup</AssemblyName>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Sashimi.AzureResourceGroup</PackageProjectUrl>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.3

Also upgrades the `dotnet` targets to `net5.0`, cascading from [a corresponding change in `Sashimi` last year](https://github.com/OctopusDeploy/Sashimi/pull/119). This required addition of a `global.json` and some changes to the Cake script to facilitate correct framework selection on the build agents.

Upstream changes:
* OctopusDeploy/Calamari#815
* OctopusDeploy/Sashimi#134
* OctopusDeploy/Sashimi.AzureScripting#20

Issues:
* OctopusDeploy/Issues/issues/6794
* OctopusDeploy/Issues/issues/7177